### PR TITLE
Performance increase by removing scene objects as Rc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,11 @@ pub mod tests;
 mod types;
 mod utils;
 
-use std::rc::Rc;
-
 use types::color;
 use types::vec3::Vec3;
 use utils::config::Config;
 
-use crate::types::{traceable::TraceableGroup, ray::Ray, sphere::Sphere};
+use crate::types::{ray::Ray, sphere::Sphere, traceable::TraceableGroup};
 
 fn main() {
     // Initial configuration object
@@ -27,8 +25,8 @@ fn main() {
     // Create scene objects
     let scene_objects = TraceableGroup {
         objects: vec![
-            Rc::new(Box::new(Sphere::new(&Vec3::new(0.0, 0.0, -1.0), 0.5).unwrap())),
-            Rc::new(Box::new(Sphere::new(&Vec3::new(0.0, -100.5, -1.0), 100.0).unwrap())),
+            Box::new(Sphere::new(&Vec3::new(0.0, 0.0, -1.0), 0.5).unwrap()),
+            Box::new(Sphere::new(&Vec3::new(0.0, -100.5, -1.0), 100.0).unwrap()),
         ],
     };
 

--- a/src/tests/traceable_t.rs
+++ b/src/tests/traceable_t.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        types::{traceable::Traceable, ray::Ray, sphere::Sphere, vec3::Vec3},
+        types::{ray::Ray, sphere::Sphere, traceable::Traceable, vec3::Vec3},
         utils::constants::MAX_F,
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 pub mod color;
-pub mod traceable;
 pub mod ray;
 pub mod sphere;
+pub mod traceable;
 pub mod vec3;

--- a/src/types/sphere.rs
+++ b/src/types/sphere.rs
@@ -1,6 +1,6 @@
 use super::{
-    traceable::{HitRecord, Traceable},
     ray::Ray,
+    traceable::{HitRecord, Traceable},
     vec3::Vec3,
 };
 

--- a/src/types/traceable.rs
+++ b/src/types/traceable.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use std::rc::Rc;
-
 use super::{ray::Ray, vec3::Vec3};
 
 pub type Point3 = Vec3;
@@ -46,7 +44,7 @@ pub trait Traceable {
 }
 
 pub struct TraceableGroup {
-    pub objects: Vec<Rc<Box<dyn Traceable>>>,
+    pub objects: Vec<Box<dyn Traceable>>,
 }
 
 impl Traceable for TraceableGroup {
@@ -79,7 +77,7 @@ impl TraceableGroup {
         self.objects.clear();
     }
 
-    pub fn add(&mut self, object: Rc<Box<dyn Traceable>>) {
+    pub fn add(&mut self, object: Box<dyn Traceable>) {
         self.objects.push(object);
     }
 }


### PR DESCRIPTION
- Scene objects in `TraceableGroup` are no longer stored as `rc::Rc`. This has led to a huge performance boost
- `rc::Rc` may need to be brought back later if shared ownership is indeed required.